### PR TITLE
Update tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,6 @@ module "vpc" {
 
   tags = {
     KubernetesCluster                 = "${terraform.workspace}-eks"
-    "kubernetes.io/role/internal-elb" = ""
     Terraform                         = "true"
     Environment                       = "${terraform.workspace}-vpc"
   }


### PR DESCRIPTION
In the new terraform version and eks-module version, the empty value tags cause problems in the workers since the tags with empty values are applied in the following way:
```terraform
{
                key                 = "kubernetes.io/role/internal-elb"
                propagate_at_launch = "true"
}
```
and therefore since the value is missing terraform doesn't let you create the workers.
